### PR TITLE
Prepare CDC release

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,13 +11,3 @@ Provides support for database stores such as: `MySQL`, `PostgreSQL`, `MongoDB`, 
 include::spring-cloud-starter-stream-source-cdc-debezium/README.adoc[]
 
 ---
-
-### CDC Spring Boot Starter
-
-*Description*: Spring Boot Starter for easy integration of https://debezium.io[Debezium] in Spring Boot applications.
-
-To use it you just add the `cdc-debezium-spring-boot-starter` dependency to your application POM and implement your own `Consumer<SourceRecord>` handler to process the incoming database change events. Follow the link below for further instructions.
-
-include::spring-cloud-starter-stream-common-cdc-debezium/cdc-debezium-spring-boot-starter/README.adoc[]
-
----

--- a/spring-cloud-starter-stream-common-cdc-debezium/cdc-debezium-spring-boot-starter/README.adoc
+++ b/spring-cloud-starter-stream-common-cdc-debezium/cdc-debezium-spring-boot-starter/README.adoc
@@ -1,7 +1,9 @@
 //tag::ref-doc[]
 = Debezium Spring Boot Starter
 
-Convenience starter for https://debezium.io[Debezium] integrating  in Spring Boot applications.
+Spring Boot Starter for easy integration of https://debezium.io[Debezium] in Spring Boot applications.
+
+To use it you just add the `cdc-debezium-spring-boot-starter` dependency to your application POM and implement your own `Consumer<SourceRecord>` handler to process the incoming database change events. Follow the link below for further instructions.
 
 https://en.wikipedia.org/wiki/Change_data_capture[Change Data Capture] (CDC) Spring Boot Starter that allows capturing change events from various databases including `MySQL`, `PostgreSQL`, `MongoDB`, `Oracle` and `SQL Server`.
 

--- a/spring-cloud-starter-stream-common-cdc-debezium/spring-cloud-starter-stream-common-cdc-debezium-core/src/main/java/org/springframework/cloud/stream/app/cdc/common/core/CdcCommonProperties.java
+++ b/spring-cloud-starter-stream-common-cdc-debezium/spring-cloud-starter-stream-common-cdc-debezium-core/src/main/java/org/springframework/cloud/stream/app/cdc/common/core/CdcCommonProperties.java
@@ -23,6 +23,7 @@ import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
+import io.debezium.connector.mongodb.MongoDbConnector;
 import io.debezium.connector.mysql.MySqlConnector;
 import io.debezium.connector.oracle.OracleConnector;
 import io.debezium.connector.postgresql.PostgresConnector;
@@ -174,7 +175,7 @@ public class CdcCommonProperties {
 	public enum ConnectorType {
 		mysql(MySqlConnector.class.getName()),
 		postgres(PostgresConnector.class.getName()),
-		mongodb(CdcConnectorConfiguration.MongodbSourceConnector.class.getName()),
+		mongodb(MongoDbConnector.class.getName()),
 		oracle(OracleConnector.class.getName()),
 		sqlserver(SqlServerConnector.class.getName());
 

--- a/spring-cloud-starter-stream-source-cdc-debezium/README.adoc
+++ b/spring-cloud-starter-stream-source-cdc-debezium/README.adoc
@@ -31,64 +31,7 @@ $$cdc.stream.header.key$$:: $$When true the source record's key data is serializ
 $$cdc.stream.header.offset$$:: $$When true the source record's offset metadata is serialized into the outbound message header under cdc.offset.$$ *($$Boolean$$, default: `$$false$$`)*
 //end::configuration-properties[]
 
-.Table Shortcut Properties Mapping
-|===
-| Shortcut | Original | Description
-
-|cdc.connector
-|cdc.config.connector.class
-|`mysql` : MySqlConnector, `postgres` : PostgresConnector, `mongodb` : MongodbSourceConnector, `oracle` : OracleConnector, `sqlserver` : SqlServerConnector
-
-|cdc.name
-|cdc.config.name
-|
-
-|cdc.offset.flush-interval
-|cdc.config.offset.flush.interval.ms
-|
-
-|cdc.offset.commit-timeout
-|cdc.config.offset.flush.timeout.ms
-|
-
-|cdc.offset.policy
-|cdc.config.offset.commit.policy
-|`periodic` : PeriodicCommitOffsetPolicy, `always` : AlwaysCommitOffsetPolicy
-
-|cdc.offset.storage
-|cdc.config.offset.storage
-|`metadata` : MetadataStoreOffsetBackingStore, `file` : FileOffsetBackingStore, `kafka` : KafkaOffsetBackingStore, `memory` : MemoryOffsetBackingStore
-
-|cdc.flattering.drop-tombstones
-|cdc.config.drop.tombstones
-|
-
-|cdc.flattering.delete-handling-mode
-|cdc.config.delete.handling.mode
-|`none` : none, `drop` : drop, `rewrite` : rewrite
-
-|===
-
-//end::ref-doc[]
-
-== Build
-
-Build involves two-stages. First build the apps and generate the binder specific app starters projects:
-```
-$ ./mvnw clean install -PgenerateApps
-```
-
-You can find the corresponding binder based projects in the `apps` subfolder. You can then cd into the apps folder:
-
-```
-$ cd apps
-```
-and build all binder projects
-```
-$ ./mvnw clean package
-```
-
-== Testing
+== Database Support
 
 The `CDC Source` is based on Debezium, which currently support the following five datastores: `MySQL`, `PostgreSQL`, `MongoDB`, `Oracle` and `SQL Server` databases.
 
@@ -286,16 +229,68 @@ wget https://raw.githubusercontent.com/debezium/debezium-examples/master/tutoria
 cat ./inventory.sql | docker exec -i dbz_oracle sqlplus debezium/dbz@//localhost:1521/ORCLPDB1
 ----
 
-TODO
+//end::ref-doc[]
 
-== Examples
+== Build
+
+Build involves two-stages. First build the apps and generate the binder specific app starters projects:
+```
+$ ./mvnw clean install -PgenerateApps
+```
+
+You can find the corresponding binder based projects in the `apps` subfolder. You can then cd into the apps folder:
 
 ```
-java -jar cdc-debezium-source.jar ... use the properties TODO
+$ cd apps
+```
+and build all binder projects
+```
+$ ./mvnw clean package
 ```
 
-And here is a example pipeline that uses cdc:
+== Run standalone
 
 ```
-cdc-stream= TODO
+java -jar cdc-debezium-source.jar --cdc.connector=mysql --cdc.name=my-sql-connector --cdc.config.database.server.id=85744 --cdc.config.database.server.name=my-app-connector --cdc.config.database.user=debezium --cdc.config.database.password=dbz --cdc.config.database.hostname=localhost --cdc.config.database.port=3306 --cdc.schema=true --cdc.flattering.enabled=true
 ```
+
+== Debezium property mapping
+
+Following table illustrates how the
+.Table Shortcut Properties Mapping
+|===
+| Shortcut | Original | Description
+
+|cdc.connector
+|cdc.config.connector.class
+|`mysql` : MySqlConnector, `postgres` : PostgresConnector, `mongodb` : MongodbSourceConnector, `oracle` : OracleConnector, `sqlserver` : SqlServerConnector
+
+|cdc.name
+|cdc.config.name
+|
+
+|cdc.offset.flush-interval
+|cdc.config.offset.flush.interval.ms
+|
+
+|cdc.offset.commit-timeout
+|cdc.config.offset.flush.timeout.ms
+|
+
+|cdc.offset.policy
+|cdc.config.offset.commit.policy
+|`periodic` : PeriodicCommitOffsetPolicy, `always` : AlwaysCommitOffsetPolicy
+
+|cdc.offset.storage
+|cdc.config.offset.storage
+|`metadata` : MetadataStoreOffsetBackingStore, `file` : FileOffsetBackingStore, `kafka` : KafkaOffsetBackingStore, `memory` : MemoryOffsetBackingStore
+
+|cdc.flattering.drop-tombstones
+|cdc.config.drop.tombstones
+|
+
+|cdc.flattering.delete-handling-mode
+|cdc.config.delete.handling.mode
+|`none` : none, `drop` : drop, `rewrite` : rewrite
+
+|===

--- a/spring-cloud-starter-stream-source-cdc-debezium/pom.xml
+++ b/spring-cloud-starter-stream-source-cdc-debezium/pom.xml
@@ -133,9 +133,49 @@
 			<plugin>
 				<groupId>io.fabric8</groupId>
 				<artifactId>docker-maven-plugin</artifactId>
-				<version>0.28.0</version>
+				<version>0.29.0</version>
 				<configuration>
 					<images>
+<!--						<image>-->
+<!--							<alias>test-mongodb2</alias>-->
+<!--							<name>%a/example-mongodb:${project.version}</name>-->
+<!--							<build>-->
+<!--								<dockerFileDir>${project.basedir}/src/test/docker/mongodb</dockerFileDir>-->
+<!--								<filter>@</filter>-->
+<!--							</build>-->
+<!--							<run>-->
+<!--								<hostname>localhost</hostname>-->
+<!--								<env>-->
+<!--									<MONGODB_USER>debezium</MONGODB_USER>-->
+<!--									<MONGODB_PASSWORD>dbz</MONGODB_PASSWORD>-->
+<!--								</env>-->
+<!--								<ports>-->
+<!--									<port>27017:27017</port>-->
+<!--								</ports>-->
+<!--								<wait>-->
+<!--									<log>port: 3306</log>-->
+<!--									<time>300000</time>-->
+<!--								</wait>-->
+<!--							</run>-->
+<!--						</image>-->
+						<!--<image>-->
+							<!--<alias>test-mongodb</alias>-->
+							<!--<name>debezium/example-mongodb:0.10</name>-->
+							<!--<run>-->
+								<!--<hostname>localhost</hostname>-->
+								<!--<env>-->
+									<!--<MONGODB_USER>debezium</MONGODB_USER>-->
+									<!--<MONGODB_PASSWORD>dbz</MONGODB_PASSWORD>-->
+								<!--</env>-->
+								<!--<ports>-->
+									<!--<port>27017:27017</port>-->
+								<!--</ports>-->
+								<!--<wait>-->
+									<!--<log>port: 3306</log>-->
+									<!--<time>300000</time>-->
+								<!--</wait>-->
+							<!--</run>-->
+						<!--</image>-->
 						<image>
 							<alias>mysql</alias>
 							<name>debezium/example-mysql:0.10</name>
@@ -213,6 +253,13 @@
 					<execution>
 						<id>stop</id>
 						<phase>post-integration-test</phase>
+						<goals>
+							<goal>stop</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>stop-pre</id>
+						<phase>clean</phase>
 						<goals>
 							<goal>stop</goal>
 						</goals>

--- a/spring-cloud-starter-stream-source-cdc-debezium/src/test/docker/mongodb/Dockerfile
+++ b/spring-cloud-starter-stream-source-cdc-debezium/src/test/docker/mongodb/Dockerfile
@@ -1,0 +1,16 @@
+FROM debezium/example-mongodb:0.10
+
+## Bundle data source
+COPY entrypoint.sh /usr/local/bin/
+
+# Grant permissions for the import-data script to be executable
+RUN chmod +x /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/init-inventory.sh
+
+CMD  /usr/local/bin/entrypoint.sh
+#CMD ["mongod", "--replSet", "rs0", "--auth"]
+#CMD ["/bin/bash", "./entrypoint.sh"]
+
+#CMD ["mongod", "--replSet", "rs0", "--auth", "&", "sleep", "10s", "&", "/usr/local/bin/init-inventory.sh"]
+#CMD mongod --replSet rs0 --auth
+

--- a/spring-cloud-starter-stream-source-cdc-debezium/src/test/docker/mongodb/entrypoint.sh
+++ b/spring-cloud-starter-stream-source-cdc-debezium/src/test/docker/mongodb/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+mongod --replSet rs0 --auth & sleep 10s

--- a/spring-cloud-starter-stream-source-cdc-debezium/src/test/docker/mongodb/import-data.sh
+++ b/spring-cloud-starter-stream-source-cdc-debezium/src/test/docker/mongodb/import-data.sh
@@ -1,0 +1,5 @@
+#wait for the SQL Server to come up
+sleep 10s
+
+#populate the db
+/usr/local/bin/init-inventory.sh

--- a/spring-cloud-starter-stream-source-cdc-debezium/src/test/java/org/springframework/cloud/stream/app/cdc/source/CdcSourceIntegrationTests.java
+++ b/spring-cloud-starter-stream-source-cdc-debezium/src/test/java/org/springframework/cloud/stream/app/cdc/source/CdcSourceIntegrationTests.java
@@ -158,35 +158,34 @@ public abstract class CdcSourceIntegrationTests {
 		}
 	}
 
-	@TestPropertySource(properties = {
-			"cdc.connector=mongodb",
-
-			"cdc.config.tasks.max=1",
-			"cdc.config.mongodb.hosts=rs0/localhost:27017",
-			"cdc.config.mongodb.name=dbserver1",
-			"cdc.config.mongodb.user=debezium",
-			"cdc.config.mongodb.password=dbz",
-			"cdc.config.database.whitelist=inventory",
-	})
-	public static class CdcSqlMongoDbTests extends CdcSourceIntegrationTests {
-
-		@Test
-		@Ignore
-		public void testOne() throws InterruptedException {
-
-			Message<?> received = messageCollector.forChannel(this.channels.output()).poll(10, TimeUnit.SECONDS);
-			Assert.assertNotNull(received);
-
-			do {
-				received = messageCollector.forChannel(this.channels.output()).poll(10, TimeUnit.SECONDS);
-				if (received != null) {
-					System.out.println("Headers: " + received.getHeaders());
-					System.out.println("Payload: " + received.getPayload());
-				}
-			} while (received != null);
-
-		}
-	}
+	//@TestPropertySource(properties = {
+	//		"cdc.connector=mongodb",
+	//
+	//		"cdc.config.tasks.max=1",
+	//		"cdc.config.mongodb.hosts=rs0/localhost:27017",
+	//		"cdc.config.mongodb.name=dbserver1",
+	//		"cdc.config.mongodb.user=debezium",
+	//		"cdc.config.mongodb.password=dbz",
+	//		"cdc.config.database.whitelist=inventory",
+	//})
+	//public static class CdcSqlMongoDbTests extends CdcSourceIntegrationTests {
+	//
+	//	@Test
+	//	public void testOne() throws InterruptedException {
+	//
+	//		Message<?> received = messageCollector.forChannel(this.channels.output()).poll(10, TimeUnit.SECONDS);
+	//		Assert.assertNotNull(received);
+	//
+	//		do {
+	//			received = messageCollector.forChannel(this.channels.output()).poll(10, TimeUnit.SECONDS);
+	//			if (received != null) {
+	//				System.out.println("Headers: " + received.getHeaders());
+	//				System.out.println("Payload: " + received.getPayload());
+	//			}
+	//		} while (received != null);
+	//
+	//	}
+	//}
 
 	@SpringBootConfiguration
 	@EnableAutoConfiguration


### PR DESCRIPTION
 - Remove the cdc to debezium properties mapping from the generated docs, but leave it in the README
 - Move the how to use doc section into the generated docs.
 - Ensure that the test docker images are stopped during maven clean phase.
 - Disable the MongoDB test as it generates dynamic collection names that can not be accessed automatically

   Resolves #2